### PR TITLE
introduce error objects

### DIFF
--- a/lib/promise.js
+++ b/lib/promise.js
@@ -253,7 +253,12 @@ Promise.prototype.request = function(method, url, params, cb, opts) {
 	var self = this;
 	this.instance.request(method, url, params, function(err, res, document, last_try) {
 		if (err !== null) {
-			self.error((self.name!==method?'[' + method + '] ':'') + (res?res.url.href:url) + ' - ' + err);
+			self.error(
+				Object.assign({
+					method: method,
+				  url: res?res.url.href:url
+				}, err)
+			);
 
 			if (last_try === true) { // Call callback after **final** request only
 				if (cb.length === 2)
@@ -414,7 +419,8 @@ Promise.prototype.error = function(cb) {
 		startRootPromise(this);
 		configInstance(this, 'error', true);
 	}else{
-		this.errorNext('('+this.name+') '+cb);
+		Object.assign(cb, {method: this.name});
+		this.errorNext(cb);
 	}
 	return this;
 }

--- a/lib/promises.js
+++ b/lib/promises.js
@@ -123,7 +123,7 @@ var Promise = {
             var res = context.doc().find(selector);
 
         if (res.length < 1) {
-            this.error('no results for "' + selector + '"' + getLocation(context.doc()));
+            this.error({errorType: 'ERR_SELECTOR', errorMessage: 'no results for "' + selector + '"' + getLocation(context.doc()), method: 'find', context: context, data: data, selector: selector});
             done();
             return;
         }
@@ -195,7 +195,7 @@ var Promise = {
             url = url(context, data.obj);
         }
         if (url === undefined) {
-            this.error('no URL found');
+            this.error({errorType: 'ERR_NO_URL', errorMessage: 'no URL found', method: 'get', context: context, data: data});
             return;
         }
         if (context !== undefined) {
@@ -229,21 +229,21 @@ var Promise = {
         var form = context.get('form:has(input[type="password"])')
 
         if (form === null) {
-            this.error('No login form found');
+            this.error({errorType: 'ERR_NO_LOGIN_FORM', errorMessage: 'No login form found', method: 'login', context: context, data: data});
             return;
         }
 
         var userInput = form.get('input[(not(@type) or @type="text") and @name]:before(input[type="password"]):last');
 
         if (!userInput) {
-            this.error('No user field found');
+            this.error({errorType: 'ERR_NO_LOGIN_USER_FIELD', errorMessage: 'No user field found', method: 'login', context: context, data: data});
             return;
         }
 
         var passInput = userInput.get('following::input[type="password"]');
 
         if (!passInput) {
-            this.error('No password field found');
+            this.error({errorType: 'ERR_NO_LOGIN_PASSWORD_FIELD', errorMessage: 'No password field found' , method: 'login', context: context, data: data});
             return;
         }
 
@@ -268,13 +268,13 @@ var Promise = {
         this.request(method, url, params, function(c) {
             if (typeof fail === 'string') {
                 if (c.find(fail).length !== 0) {
-                    self.error('failed - found "' + fail + '"');
+                    self.error({errorType: 'ERR_LOGIN_FAILED', errorMessage: 'failed - found "' + fail + '"', method: 'login', context: context, data: data});
                     return;
                 }
             }
             if (typeof success === 'string') {
                 if (c.find(success).length === 0) {
-                    self.error('failed - "' + success + '" not found');
+                    self.error({errorType: 'ERR_LOGIN_FAILED', errorMessage: 'failed - "' + success + '" not found', method: 'login', context: context, data: data});
                     return;
                 }
             }
@@ -307,7 +307,7 @@ var Promise = {
         if (typeof limit === 'string') {
             limit = getContent(doc.get(limit));
             if (limit === null) {
-                this.error('no results for limit selector ' + selector);
+                this.error({errorType: 'ERR_PAGE_SELECTOR_LIMIT', errorMessage: 'no results for limit selector ' + selector, method: 'page', context: context, data: data, selector: selector});
                 return;
             }
             limit = parseInt(limit.replace(/[^0-9]+/g, '')) - 1;
@@ -328,7 +328,7 @@ var Promise = {
             var node = doc.get(selector);
             if (!node) {
                 if (this.config().error === true)
-                    this.error('no results for "' + selector + '" in ' + url);
+                    this.error({errorType: 'ERR_PAGE_SELECTOR_URL_NO_RESULT', errorMessage: 'no results for "' + selector + '" in ' + url, method: 'page', context: context, data: data, selector: selector, url: url});
                 return;
             } else if (node.nodeName === 'form') {
                 var formData = formQueryParams(node);
@@ -347,7 +347,7 @@ var Promise = {
                             value = getContent(node);
                         params[name] = value;
                     } else {
-                        this.error('no URL found in ' + selector);
+                        this.error({errorType: 'ERR_PAGE_SELECTOR_NO_URL', errorMessage: 'no URL found in ' + selector, method: 'page', context: context, data: data, selector: selector});
                         return;
                     }
                 }
@@ -472,7 +472,7 @@ var Promise = {
 
         var form = context.get(selector);
         if (form === null) {
-            this.error(selector + ' not found');
+            this.error({errorType: 'ERR_SUBMIT_SELECTOR_NOT_FOUND', errorMessage: selector + ' not found', method: 'submit', context: context, data: data, selector: selector});
             this.next.start(null);
             return;
         }

--- a/test/get.js
+++ b/test/get.js
@@ -55,7 +55,7 @@ module.exports.error_404 = function(assert) {
     osmosis.get(url+'/404')
     .config('tries', tries)
     .error(function(msg) {
-        if (msg.indexOf('404') > -1)
+        if (msg.statusCode === 404)
             tries--;
     })
     .done(function() {
@@ -69,7 +69,7 @@ module.exports.error_redirect = function(assert) {
     osmosis.get(url+'/error-redirect')
     .config('follow', redirects)
     .error(function(msg) {
-        if (msg.indexOf('redirect') > -1)
+        if (msg.errorMessage.indexOf('redirect') > -1)
             redirects--;
     })
     .done(function() {
@@ -83,7 +83,7 @@ module.exports.error_parse = function(assert) {
     osmosis.get(url+'/error-parse')
     .config('tries', tries)
     .error(function(msg) {
-        if (msg.indexOf('empty') > -1)
+        if (msg.errorMessage.indexOf('empty') > -1)
             tries--;
     })
     .done(function() {


### PR DESCRIPTION
until now errors were always string. this commit changes this to error
Objects, with the intention to be able to programmatically handle
errors better (without string parsing).

Example Use Case: Crawling a website and checking if links are valid.
Current State: when a link points to a ressource which is not
available, it returns an error with a string containing 404. State with
this commit, it returns an error with an errorType, statusCode etc,
which can be processed easily.