### PR TITLE
Fix bug affecting getLimit() in Paginate command

### DIFF
--- a/lib/commands/paginate.js
+++ b/lib/commands/paginate.js
@@ -142,14 +142,14 @@ module.exports.paginate = function (selector, limit) {
     this.limit = limit;
 
     switch (typeof limit) {
-        case 'number':
-            this.getLimit = getLimitArg;
-            break;
         case 'string':
             this.getLimit = getLimitSelector;
             break;
         case 'function':
             this.getLimit = getLimitFunction;
+            break;
+        default:
+            this.getLimit = getLimitArg;
             break;
     }
 

--- a/lib/commands/paginate.js
+++ b/lib/commands/paginate.js
@@ -25,7 +25,7 @@ var form = require('../form-functions.js');
 
 function Paginate(context, data, next, done) {
     var selector = this.selector,
-        limit = this.getLimit(this.limit),
+        limit = this.getLimit(this.limit, context, data),
         document = context.doc(),
         count = document.request.count || 1,
         self = this,


### PR DESCRIPTION
If `this.limit` is a string, then `this.getLimit` points to `getLimitSelector()`, which expects a `context` parameter.

This parameter isn't being passed, so a fatal error occurs in `getLimitSelector()`:

```
lib/commands/paginate.js:115
    var node = context.get(selector), value;
                      ^
TypeError: Cannot read property 'get' of undefined
    at Object.getLimitSelector [as getLimit] (lib/commands/paginate.js:115:23)
    at Object.Paginate [as cb] (lib/commands/paginate.js:28:22)
    at Object.Command.start (lib/Command.js:157:21)
    at lib/Command.js:164:18
    at lib/commands/get.js:36:25
    at lib/Command.js:390:17
    at index.js:258:21
    at lib/Request.js:84:9
```

A similar problem occurs if `this.limit` is a function, in which case `this.getLimit` points to `getLimitFunction()`, which expects `context` and `data` parameters.