### PR TITLE
Fix bug affecting Cookie command

### DIFF
--- a/lib/commands/cookie.js
+++ b/lib/commands/cookie.js
@@ -16,7 +16,11 @@ module.exports = function (name, value) {
     var opts = this.getOpts();
 
     if (!opts.hasOwnProperty('cookies')) {
-        opts.cookies = extend({}, opts.cookies);
+        if (opts.cookies !== undefined) {
+            opts.cookies = extend({}, opts.cookies);
+        } else {
+            opts.cookies = {};
+        }
     }
 
     if (value === null) {


### PR DESCRIPTION
If the `opts` object doesn't have a `cookies` property, then that property needs to be created and initialised with an empty object.

`extend({}, opts.cookies)` causes a fatal error, because `opts.cookies` is `undefined`, so `Object.keys(donor)` in `extend()` throws a `TypeError`:

```
lib/commands/cookie.js:32
    var key, keys = Object.keys(donor),
                           ^
TypeError: Cannot convert undefined or null to object
    at Function.keys (native)
    at extend (lib/commands/cookie.js:32:28)
    at Object.module.exports (lib/commands/cookie.js:19:24)
    at lib/Command.js:462:22
```