### PR TITLE
Parse xml responses files as xml files

### DIFF
--- a/lib/Request.js
+++ b/lib/Request.js
@@ -46,8 +46,9 @@ function Request(method, url, params, opts, tries, callback) {
         }
 
         if (opts.parse !== false) {
-            document = libxml.parseHtml(document,
-                                        { baseUrl: location.href, huge: true });
+            var parseMethod = getResponseType(res.headers['content-type']) === 'xml' ? 'parseXml' : 'parseHtml';
+            document = libxml[parseMethod](document,
+                                           { baseUrl: location.href, huge: true });
         }
 
         if (document === null) {


### PR DESCRIPTION
For example it fixes interpretation of opening `<link>` tag in RSS as HTML inline tag `<link />` without text content