### PR TITLE
Remove empty query string from base path when params are not passed.

### DIFF
--- a/lib/Command.js
+++ b/lib/Command.js
@@ -339,13 +339,15 @@ Command.prototype.request = function (method, context, href, params, callback) {
 
     url.method = method;
     url.params = params;
-
     if (method === 'get') {
-        for (key in params) {
-            url.query[key] = params[key];
+        if (params instanceof Object && params !== null) {
+            for (key in params) {
+                url.query[key] = params[key];
+            }
         }
-
-        url.params = url.query;
+        if (!isEmptyObject(url.query)) {
+            url.params = url.query;
+        }
         url.search = qs.stringify(url.query);
         url.href   = URL.format(url);
     }
@@ -423,6 +425,16 @@ Command.prototype.request = function (method, context, href, params, callback) {
         return this;
     };
 });
+
+function isEmptyObject(obj) {
+    if (Object.keys) return !Object.keys(obj).length;
+    for (var key in obj) {
+        if (Object.prototype.hasOwnProperty.call(obj, key)) {
+            return false;
+        }
+    }
+    return true;
+}
 
 function extend(object, donor) {
     var key, keys = Object.keys(donor),

--- a/lib/Request.js
+++ b/lib/Request.js
@@ -12,7 +12,7 @@ var needle = require('needle'),
 
 function Request(method, url, params, opts, tries, callback) {
     var location = url;
-    var needleParams = (params && Object.keys(params).length > 0) ? params : undefined
+    var needleParams = (params && !isEmptyObject(params)) ? params : undefined
     return needle.request(method,
                           url.href,
                           needleParams,
@@ -161,6 +161,16 @@ function extend(object, donor) {
     }
 
     return object;
+}
+
+function isEmptyObject(obj) {
+    if (Object.keys) return !Object.keys(obj).length;
+    for (var key in obj) {
+        if (Object.prototype.hasOwnProperty.call(obj, key)) {
+            return false;
+        }
+    }
+    return true;
 }
 
 module.exports = Request;

--- a/lib/Request.js
+++ b/lib/Request.js
@@ -12,10 +12,10 @@ var needle = require('needle'),
 
 function Request(method, url, params, opts, tries, callback) {
     var location = url;
-
+    var needleParams = (params && Object.keys(params).length > 0) ? params : undefined
     return needle.request(method,
                           url.href,
-                          params,
+                          needleParams,
                           opts,
                           function (err, res, data) {
         var document;
@@ -44,7 +44,7 @@ function Request(method, url, params, opts, tries, callback) {
         } else {
             document = data;
         }
-        
+
         if (opts.parse === false) {
             callback(null, res, document);
             return;

--- a/lib/Request.js
+++ b/lib/Request.js
@@ -12,10 +12,9 @@ var needle = require('needle'),
 
 function Request(method, url, params, opts, tries, callback) {
     var location = url;
-    var needleParams = (params && !isEmptyObject(params)) ? params : undefined
     return needle.request(method,
                           url.href,
-                          needleParams,
+                          params,
                           opts,
                           function (err, res, data) {
         var document;
@@ -161,16 +160,6 @@ function extend(object, donor) {
     }
 
     return object;
-}
-
-function isEmptyObject(obj) {
-    if (Object.keys) return !Object.keys(obj).length;
-    for (var key in obj) {
-        if (Object.prototype.hasOwnProperty.call(obj, key)) {
-            return false;
-        }
-    }
-    return true;
 }
 
 module.exports = Request;

--- a/test/get.js
+++ b/test/get.js
@@ -140,6 +140,19 @@ module.exports.multiple = function (assert) {
     }, 5000);
 }
 
+module.exports.absentQueryString = function (assert) {
+    var found = false;
+    osmosis.get(url + '/query')
+    .find('div')
+    .set({ content: 'p' })
+    .data((data) => {
+      found = true
+    })
+    .done(function () {
+        assert.ok(found);
+        assert.done();
+    });
+};
 
 server('/get', function (url, req, res) {
     if (url.query.redirect !== undefined) {
@@ -175,5 +188,17 @@ server('/redirect', function (url, req, res) {
 
 server('/test-test', function (url, req, res) {
     res.write('<p>success</p>');
+    res.end();
+});
+
+server('/query', function (url, req, res) {
+    if (url.path === '/query?') {
+        console.log('empty', url)
+        res.writeHead(404);
+        res.end();
+        return;
+    }
+
+    res.write('<div><p>test</p></div>');
     res.end();
 });

--- a/test/get.js
+++ b/test/get.js
@@ -145,7 +145,7 @@ module.exports.absentQueryString = function (assert) {
     osmosis.get(url + '/query')
     .find('div')
     .set({ content: 'p' })
-    .data((data) => {
+    .data(function (data) {
       found = true
     })
     .done(function () {
@@ -193,7 +193,6 @@ server('/test-test', function (url, req, res) {
 
 server('/query', function (url, req, res) {
     if (url.path === '/query?') {
-        console.log('empty', url)
         res.writeHead(404);
         res.end();
         return;

--- a/test/paginate.js
+++ b/test/paginate.js
@@ -11,7 +11,8 @@ module.exports.link = function (assert) {
     .paginate('a[rel="next"]', 3)
     .set('page', 'div')
     .then(function (context, data) {
-        var page = context.request.params.page || 1;
+        var params = context.request.params;
+        var page = (params && params.page) || 1;
 
         assert.equal(page, data.page);
         assert.equal(page, ++count);
@@ -29,7 +30,8 @@ module.exports.param = function (assert) {
     .paginate({ page: +1 }, 3)
     .set('page', 'div')
     .then(function (context, data) {
-        var page = context.request.params.page || 1;
+        var params = context.request.params;
+        var page = (params && params.page) || 1;
 
         assert.equal(page, data.page);
         assert.equal(page, ++count);
@@ -47,7 +49,8 @@ module.exports.form = function (assert) {
     .paginate('form', 3)
     .set('page', 'div')
     .then(function (context, data) {
-        var page = context.request.params.page || 1;
+        var params = context.request.params;
+        var page = (params && params.page) || 1;
 
         assert.ok(page == data.page);
         assert.ok(page == ++count);


### PR DESCRIPTION
This is a proposed solution to this issue: https://github.com/rchipka/node-osmosis/issues/187.

I added a test which highlights the issue too.

Let me know your thoughts.