### PR TITLE
Fix improper object cloning

### DIFF
--- a/lib/Command.js
+++ b/lib/Command.js
@@ -288,7 +288,7 @@ Command.prototype.request = function (method, context, href, params, callback) {
     var self     = this,
         length   = callback.length,
         instance = self.instance,
-        opts     = Object.create(this.getOpts()),
+        opts     = require('util')._extend(this.getOpts()),
         url, document, key, proxies;
 
     if (!href || href.length === 0) {


### PR DESCRIPTION
opts were not being properly copied into this.request from with a .then() command.