### PR TITLE
use getHeaders in Request.js

### DIFF
--- a/lib/Request.js
+++ b/lib/Request.js
@@ -67,7 +67,7 @@ function Request(method, url, params, opts, tries, callback) {
                 return;
             }
 
-            location.headers    = res.req._headers;
+            location.headers    = res.req.getHeaders();
             location.proxy      = opts.proxy;
             location.user_agent = opts.user_agent;
 


### PR DESCRIPTION
req._headers is deprecated 
need to use req.getHeaders() instead